### PR TITLE
Delete PRI, UNI constraint in create_table_as marco

### DIFF
--- a/dbt/include/tidb/macros/adapters.sql
+++ b/dbt/include/tidb/macros/adapters.sql
@@ -58,7 +58,7 @@
         {{ relation.include(database=False) }}
         (
             {% for row in table %}
-                {{ row[0] }}
+                `{{ row[0] }}`
                 {{ row[1] }}
                 {% if row[2] == "NO" %} not null {% endif %}
                 {% if row[3] == "PRI" %} primary key {% endif %}

--- a/dbt/include/tidb/macros/adapters.sql
+++ b/dbt/include/tidb/macros/adapters.sql
@@ -61,8 +61,6 @@
                 `{{ row[0] }}`
                 {{ row[1] }}
                 {% if row[2] == "NO" %} not null {% endif %}
-                {% if row[3] == "PRI" %} primary key {% endif %}
-                {% if row[3] == "UNI" %} unique {% endif %}
                 {% if not loop.last %},{% endif %}
             {% endfor %}
         )

--- a/dbt/include/tidb/macros/adapters.sql
+++ b/dbt/include/tidb/macros/adapters.sql
@@ -67,7 +67,7 @@
     {% endcall %}
 
     {# 3. copy data from view to table #}
-    {% call statement ('cpoy_data_from_view_to_table') %}
+    {% call statement ('copy_data_from_view_to_table') %}
         insert into {{ relation.include(database=False) }} select * from {{ relation.schema }}.{{ temp_view }}
     {% endcall %}
 


### PR DESCRIPTION
### What problem does this PR solve?
`CREATE TABLE AS SELECT` should not copy PRI and UNI constraints.
For more information about this SQL, see the [MySQL document](https://dev.mysql.com/doc/refman/8.0/en/create-table-select.html).
It says that:
> [CREATE TABLE ... SELECT](https://dev.mysql.com/doc/refman/8.0/en/create-table.html) does not automatically create any indexes for you. This is done intentionally to make the statement as flexible as possible. If you want to have indexes in the created table, you should specify these before the [SELECT](https://dev.mysql.com/doc/refman/8.0/en/select.html) statement:
> For CREATE TABLE ... SELECT, the destination table does not preserve information about whether columns in the selected-from table are generated columns. The [SELECT](https://dev.mysql.com/doc/refman/8.0/en/select.html) part of the statement cannot assign values to generated columns in the destination table.
>For CREATE TABLE ... SELECT, the destination table does preserve expression default values from the original table.

So we need to add `DEFAULT` message in `tidb__create_table_as` marco.

### What is changed and how does it work?
Delete PRI, UNI in `tidb__create_table_as` marco.

### Check List
- [ ] unit test
- [x] integration test
- [ ] modify doc
- [x] change source code
